### PR TITLE
invoke ovs-vswitchd with --pidfile flag in supervisord.conf

### DIFF
--- a/1.10.0/supervisord.conf
+++ b/1.10.0/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.10.2/supervisord.conf
+++ b/1.10.2/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.11.0/supervisord.conf
+++ b/1.11.0/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.4.6/supervisord.conf
+++ b/1.4.6/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.5.0/supervisord.conf
+++ b/1.5.0/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.6.1/supervisord.conf
+++ b/1.6.1/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.7.0/supervisord.conf
+++ b/1.7.0/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.7.1/supervisord.conf
+++ b/1.7.1/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.7.2/supervisord.conf
+++ b/1.7.2/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.7.3/supervisord.conf
+++ b/1.7.3/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.9.0/supervisord.conf
+++ b/1.9.0/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/1.9.3/supervisord.conf
+++ b/1.9.3/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.0.1/supervisord.conf
+++ b/2.0.1/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.0.2/supervisord.conf
+++ b/2.0.2/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.0/supervisord.conf
+++ b/2.0/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.1.0/supervisord.conf
+++ b/2.1.0/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.1.1/supervisord.conf
+++ b/2.1.1/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.1.2/supervisord.conf
+++ b/2.1.2/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.1.3/supervisord.conf
+++ b/2.1.3/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.3.1/supervisord.conf
+++ b/2.3.1/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.3.2/supervisord.conf
+++ b/2.3.2/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/2.3/supervisord.conf
+++ b/2.3/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -26,7 +26,7 @@ stderr_events_enabled=true
 stdout_events_enabled=true
 
 [program:ovs-vswitchd]
-command=/usr/local/sbin/ovs-vswitchd -v
+command=/usr/local/sbin/ovs-vswitchd -v --pidfile
 priority=20
 startsec=10
 stderr_events_enabled=true


### PR DESCRIPTION
Some of the ovs tools expect ovs-vswitchd.pid to exist on the
filesystem; as an example, ovs-appctl.

By invoking ovs-vswitchd with the --pidfile flag, creation happens
in the default location: /usr/local/var/run/openvswitch/ovs-vswitchd.pid