### PR TITLE
Explicit supervisorctl listen address

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 file = /var/run/supervisor.sock
 
 [inet_http_server]
-port = 9001
+port = *:9001
 
 [supervisord]
 nodaemon=true


### PR DESCRIPTION
When running with docker's --net=host option, supervisorctl
may fail with the following:

"Error: Could not determine IP address for hostname XXXX, please try
setting an explicit IP address in the "port" setting of your
[inet_http_server] section.  For example, instead of "port = 9001", try
"port = 127.0.0.1:9001."
